### PR TITLE
Fix author bio card overlapping blog posts

### DIFF
--- a/assets/css/modern-styles.css
+++ b/assets/css/modern-styles.css
@@ -140,6 +140,11 @@ article.page {
   margin-bottom: 2rem;
 }
 
+article.post {
+  flex: 1;
+  min-width: 0;
+}
+
 .article-wrap {
   width: 100%;
 }
@@ -158,7 +163,8 @@ article.page {
     order: 1;
   }
   
-  article.page {
+  article.page,
+  article.post {
     order: 2;
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- prevent author card from overlaying blog posts by adding responsive flex styles for post articles

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68c1be28f0b08327bfe99abf53f38eaa