### PR TITLE
Add news entry for ∞-RoPE preprint

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,3 +1,14 @@
+- date: 2025-11-26
+  type: publication
+  description: "Our new preprint <strong>∞-RoPE: Action-Controllable Infinite Video Generation Emerges From Autoregressive Self-Rollout</strong> is now available on arXiv."
+  links:
+    - text: Paper
+      url: https://arxiv.org/abs/2511.20649
+      type: paper
+    - text: Project Page
+      url: https://infinity-rope.github.io
+      type: project
+
 - date: 2025-11-07
   type: publication
   description: "Our work <strong>MotionFlow</strong> has been accepted to the <strong>AAAI 2026 Main Technical Track</strong>."

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -23,6 +23,26 @@
   year={2024}
 }"
 
+- title: "∞-RoPE: Action-Controllable Infinite Video Generation Emerges From Autoregressive Self-Rollout"
+  authors: "Hidir Yesiltepe, Tuna Han Salih Meral, Adil Kaan Akan, Kaan Oktay, Pinar Yanardag"
+  venue: "Preprint"
+  year: 2025
+  description: "∞-RoPE enables effectively infinite-horizon video generation with plug-and-play inference techniques. Block-Relativistic RoPE extends temporal reach, KV Flush enables prompt-reactive action control, and RoPE Cut supports cinematic scene transitions—all without retraining the base model."
+  featured: false
+  links:
+    - text: "Paper"
+      url: "https://arxiv.org/abs/2511.20649"
+      type: "paper"
+    - text: "Project Page"
+      url: "https://infinity-rope.github.io"
+      type: "project"
+  citation: "@article{yesiltepe2025infinityrope,
+  title={{∞}-RoPE: Action-Controllable Infinite Video Generation Emerges From Autoregressive Self-Rollout},
+  author={Yesiltepe, Hidir and Meral, Tuna Han Salih and Akan, Adil Kaan and Oktay, Kaan and Yanardag, Pinar},
+  journal={arXiv preprint arXiv:2511.20649},
+  year={2025}
+}"
+
 - title: "CONFORM: Contrast is All You Need For High-Fidelity Text-to-Image Diffusion Models"
   authors: "Tuna Han Salih Meral, Enis Simsar, Federico Tombari, Pinar Yanardag"
   venue: "CVPR 2024"


### PR DESCRIPTION
## Summary
- add a news item announcing the ∞-RoPE preprint with links to the paper and project page

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c2ca48248327bad1b076ed9b2067)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ∞-RoPE preprint to site data: new news item and a publications entry with links and citation.
> 
> - **Data updates**:
>   - **`_data/news.yml`**: Add new publication news item (2025-11-26) for `∞-RoPE` with links to paper and project page.
>   - **`_data/publications.yml`**: Add `∞-RoPE` preprint entry with description, links (paper, project), and citation; marked not featured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82ede0fb04d482154581968bc2220296ae85b297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->