### PR TITLE
Mark Waymo internship as active starting May 2026

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -13,6 +13,10 @@
   type: milestone
   description: "Selected as an Outstanding Reviewer at CVPR 2026."
 
+- date: 2026-05-18
+  type: internship
+  description: "Started a research internship at Waymo."
+
 - date: 2026-02-13
   type: milestone
   description: "Passed the Ph.D. preliminary exam and advanced to candidacy. Dissertation: <em>Representation Steering as a Control Surface for Generative Foundation Models</em>."

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ published: true
 
 ## Current and Recent Roles
 <ul class="home-highlights">
-  <li><strong>Waymo</strong> - Research Intern (Incoming, Summer 2026)</li>
+  <li><strong>Waymo</strong> - Research Intern (May 2026 - Present)</li>
   <li><strong>Virginia Tech</strong> - Research Assistant and Lab Lead (Aug 2023 - Present)</li>
   <li><strong>Amazon</strong> - Applied Scientist Intern (May 2025 - Aug 2025)</li>
   <li><strong>Adobe</strong> - Research Intern, Video Generative AI (May 2024 - Aug 2024)</li>

--- a/resume.md
+++ b/resume.md
@@ -82,7 +82,7 @@ __SteerCLR: A Contrastive Learning Approach for Unsupervised Discovery of Interp
 *Under review*
 
 ## Research Experience
-`Summer 2026 (Incoming)`
+`May 2026 - Present`
 __Waymo__
 Research Intern
 


### PR DESCRIPTION
- News entry for internship start on 2026-05-18
- Update resume entry from "Summer 2026 (Incoming)" to "May 2026 - Present"
- Update index.md Current and Recent Roles to match